### PR TITLE
Fix String Compatibility Issues in BleMouse.cpp Library

### DIFF
--- a/BleMouse.cpp
+++ b/BleMouse.cpp
@@ -139,8 +139,8 @@ void BleMouse::setBatteryLevel(uint8_t level) {
 }
 
 void BleMouse::taskServer(void* pvParameter) {
-  BleMouse* bleMouseInstance = (BleMouse *) pvParameter; //static_cast<BleMouse *>(pvParameter);
-  BLEDevice::init(bleMouseInstance->deviceName);
+  BleMouse* bleMouseInstance = (BleMouse *) pvParameter;
+  BLEDevice::init(String(bleMouseInstance->deviceName.c_str())); // Convert to Arduino String
   BLEServer *pServer = BLEDevice::createServer();
   pServer->setCallbacks(bleMouseInstance->connectionStatus);
 
@@ -148,7 +148,7 @@ void BleMouse::taskServer(void* pvParameter) {
   bleMouseInstance->inputMouse = bleMouseInstance->hid->inputReport(0); // <-- input REPORTID from report map
   bleMouseInstance->connectionStatus->inputMouse = bleMouseInstance->inputMouse;
 
-  bleMouseInstance->hid->manufacturer()->setValue(bleMouseInstance->deviceManufacturer);
+  bleMouseInstance->hid->manufacturer()->setValue(String(bleMouseInstance->deviceManufacturer.c_str())); // Convert to Arduino String
 
   bleMouseInstance->hid->pnp(0x02, 0xe502, 0xa111, 0x0210);
   bleMouseInstance->hid->hidInfo(0x00,0x02);


### PR DESCRIPTION
This commit addresses the compatibility issues between std::string and Arduino String types in the BleMouse library. Modifications have been made to `BleMouse.cpp` to ensure that std::string is properly converted to Arduino String where necessary. These changes ensure that the library functions correctly with Arduino IDE Version 2.2.1 and the developer version of the Arduino-ESP32 library (Arduino Alpha 2 Release v3.0.0 based on ESP-IDF v5.1). The library has been tested and verified to work as expected with this setup.